### PR TITLE
2week

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ dependencies {
 
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' // 타임리프에서 layout.html 사용하려고
+
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/records/2Week_JeMunKyeong.md
+++ b/records/2Week_JeMunKyeong.md
@@ -24,7 +24,7 @@
 - 이미 호감을 표시한 상대가 같은 사유로 호감표시를 했다면, 경고창과 함께 추가 안되도록 구현
     - likeable_person 테이블에서 insert가 되면 안됨
     - 구현 방법: from과 to InstamemberId를 repository에 추가, toInstaMemberId와 attractiveTypeCode를 repository에 추가하여 List로 받아와서 이미 존재하는 from, to id이고 attrativeTypeCode도 같다면 추가되지 않도록 구현
-    - from,to InstaMemberId는 같지만 attractiveTypeCode가 다르다면 기존 attractiveTypeCode는 삭제하고 새로 들어온 attractiveTypeCode를 추가하여 구현
+    - from,to InstaMemberId는 같지만 attractiveTypeCode가 다르다면 변경한 호감 사유로 set하고 save하여 저장 
 
 - 호감 상대는 최대 10명까지 등록가능
     - fromInstaMemberId를 List로 받아와 10명이상일 경우 경고창과 함께 추가 안되도록 구현
@@ -39,12 +39,12 @@
 
 1. 궁금했던 점
 
-   이미 호감을 표시한 상대의 attractiveTypeCode이 같은 경우라면 다시 set을 해주도록 처음에 구현하였지만, 작동은 하는데 db변경이 안되거나 이미 호감을 표시한 상대가 또 다른 사유로 db에 insert되어서 직접 delete 후에 다시 save를 해주었습니다. 왜 attractiveTypeCode를 set 했을 때 update가 안되는지 궁금했습니다.
+   이미 호감을 표시한 상대의 attractiveTypeCode가 변경 되었다면 다시 set하고 저장하였는데, 처음에 DB에 반영되지 않았고 그 이유에 대해 궁금하였는데 attractiveTypeCode로만 Set하여 안 되었던 부분 같았습니다. to,from InstaMemberId로 get하여 가져온 list에 해당하는 attractiveTypeCode를 변경하니 잘 수행되었습니다.
 
 
 2. 아쉬웠던 점
 
-   위의 내용이 이번주 미션을 구현하면서 가장 아쉬웠던 부분 같습니다. 여러 방법을 시도 해봤는데 update가 안 되어서 직접 삭제하고 다시 save를 해주었습니다. update를 할 수 있는 좋은 방법이 있을 거 같아 아쉬웠습니다.
+  각 기능에 대한 테스팅 코드를 작성하지 못한 부분이 가장 아쉬웠던 것 같습니다. 
 
 <br>
 

--- a/records/2Week_JeMunKyeong.md
+++ b/records/2Week_JeMunKyeong.md
@@ -1,0 +1,65 @@
+# 2Week_제문경.md
+
+## Title: [2Week] 제문경
+
+### 미션 요구사항 분석 & 체크리스트 🔍
+
+---
+- [x]  이미 등록된 호감 상대의  호감 사유가 이전과 같다면 `insert`하지 못함
+- [x]  이미 등록된 호감 상대의  호감 사유가 이전과 다르다면 `update` 수행
+- [x]  호감 상대추가는 10명까지 가능
+- [x]  호감 상대가 10명 이상이라면 경고창과 함께 추가 안 되도록 구현
+- [ ]  각 기능에 대한 테스트 코드
+- [x]  네이버 로그인
+
+<br>
+
+### N주차 미션 요약 📋
+
+---
+
+**[접근 방법]**
+
+1. **목표**
+- 이미 호감을 표시한 상대가 같은 사유로 호감표시를 했다면, 경고창과 함께 추가 안되도록 구현
+    - likeable_person 테이블에서 insert가 되면 안됨
+    - 구현 방법: from과 to InstamemberId를 repository에 추가, toInstaMemberId와 attractiveTypeCode를 repository에 추가하여 List로 받아와서 이미 존재하는 from, to id이고 attrativeTypeCode도 같다면 추가되지 않도록 구현
+    - from,to InstaMemberId는 같지만 attractiveTypeCode가 다르다면 기존 attractiveTypeCode는 삭제하고 새로 들어온 attractiveTypeCode를 추가하여 구현
+
+- 호감 상대는 최대 10명까지 등록가능
+    - fromInstaMemberId를 List로 받아와 10명이상일 경우 경고창과 함께 추가 안되도록 구현
+
+- 네이버 로그인
+    - 1Week 미션 수행 당시 구현, 네이버는 다른 정보들이 같이 나오기 때문에 id=이후로 ,가 오기 전까지 잘라서 저장하여 id만 저장될 수 있도록 구현
+
+---
+<br>
+
+**[특이사항]**
+
+1. 궁금했던 점
+
+   이미 호감을 표시한 상대의 attractiveTypeCode이 같은 경우라면 다시 set을 해주도록 처음에 구현하였지만, 작동은 하는데 db변경이 안되거나 이미 호감을 표시한 상대가 또 다른 사유로 db에 insert되어서 직접 delete 후에 다시 save를 해주었습니다. 왜 attractiveTypeCode를 set 했을 때 update가 안되는지 궁금했습니다.
+
+
+2. 아쉬웠던 점
+
+   위의 내용이 이번주 미션을 구현하면서 가장 아쉬웠던 부분 같습니다. 여러 방법을 시도 해봤는데 update가 안 되어서 직접 삭제하고 다시 save를 해주었습니다. update를 할 수 있는 좋은 방법이 있을 거 같아 아쉬웠습니다.
+
+<br>
+
+[Refactoring]
+
+- 호감상대 10이상일 경우 test 코드
+- 이미 추가한 호감상대의 사유가 같다면 추가 안 되도록 test 코드 구현
+- 사유가 같지 않다면 update 되도록 test 코드 구현
+- 사유가 같지 않을 때 update가 실행될 수 있는 코드 리팩토링
+
+<br>
+
+[1️⃣Week Refactoring ]
+
+- [x]  호감 목록 중 선택 상대 삭제 메소드 코드 리팩토링
+- [x]  호감 목록 삭제 테스트 코드 추가
+- [x]  yml ouath파일로 나누어 보이지 않도록
+- [x]  로그인 UI 변경

--- a/src/main/generated/com/ll/gramgram/base/baseEntity/QBaseEntity.java
+++ b/src/main/generated/com/ll/gramgram/base/baseEntity/QBaseEntity.java
@@ -1,0 +1,41 @@
+package com.ll.gramgram.base.baseEntity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = 1702204240L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createDate = createDateTime("createDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = createDateTime("modifyDate", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/Member/entity/QMember.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/Member/entity/QMember.java
@@ -1,0 +1,66 @@
+package com.ll.gramgram.boundedContext.member.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1579367790L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember instaMember;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final StringPath password = createString("password");
+
+    public final StringPath providerTypeCode = createString("providerTypeCode");
+
+    public final StringPath username = createString("username");
+
+    public QMember(String variable) {
+        this(Member.class, forVariable(variable), INITS);
+    }
+
+    public QMember(Path<? extends Member> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMember(PathMetadata metadata, PathInits inits) {
+        this(Member.class, metadata, inits);
+    }
+
+    public QMember(Class<? extends Member> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.instaMember = inits.isInitialized("instaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("instaMember")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMember.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/instaMember/entity/QInstaMember.java
@@ -1,0 +1,55 @@
+package com.ll.gramgram.boundedContext.instaMember.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInstaMember is a Querydsl query type for InstaMember
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QInstaMember extends EntityPathBase<InstaMember> {
+
+    private static final long serialVersionUID = -53334208L;
+
+    public static final QInstaMember instaMember = new QInstaMember("instaMember");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final ListPath<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson> fromLikeablePeople = this.<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson>createList("fromLikeablePeople", com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson.class, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.class, PathInits.DIRECT2);
+
+    public final StringPath gender = createString("gender");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final ListPath<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson> toLikeablePeople = this.<com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson>createList("toLikeablePeople", com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson.class, com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.class, PathInits.DIRECT2);
+
+    public final StringPath username = createString("username");
+
+    public QInstaMember(String variable) {
+        super(InstaMember.class, forVariable(variable));
+    }
+
+    public QInstaMember(Path<? extends InstaMember> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QInstaMember(PathMetadata metadata) {
+        super(InstaMember.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/ll/gramgram/boundedContext/likeablePerson/entity/QLikeablePerson.java
+++ b/src/main/generated/com/ll/gramgram/boundedContext/likeablePerson/entity/QLikeablePerson.java
@@ -1,0 +1,69 @@
+package com.ll.gramgram.boundedContext.likeablePerson.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QLikeablePerson is a Querydsl query type for LikeablePerson
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QLikeablePerson extends EntityPathBase<LikeablePerson> {
+
+    private static final long serialVersionUID = 1545229958L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QLikeablePerson likeablePerson = new QLikeablePerson("likeablePerson");
+
+    public final com.ll.gramgram.base.baseEntity.QBaseEntity _super = new com.ll.gramgram.base.baseEntity.QBaseEntity(this);
+
+    public final NumberPath<Integer> attractiveTypeCode = createNumber("attractiveTypeCode", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember fromInstaMember;
+
+    public final StringPath fromInstaMemberUsername = createString("fromInstaMemberUsername");
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember toInstaMember;
+
+    public final StringPath toInstaMemberUsername = createString("toInstaMemberUsername");
+
+    public QLikeablePerson(String variable) {
+        this(LikeablePerson.class, forVariable(variable), INITS);
+    }
+
+    public QLikeablePerson(Path<? extends LikeablePerson> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QLikeablePerson(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QLikeablePerson(PathMetadata metadata, PathInits inits) {
+        this(LikeablePerson.class, metadata, inits);
+    }
+
+    public QLikeablePerson(Class<? extends LikeablePerson> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromInstaMember = inits.isInitialized("fromInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("fromInstaMember")) : null;
+        this.toInstaMember = inits.isInitialized("toInstaMember") ? new com.ll.gramgram.boundedContext.instaMember.entity.QInstaMember(forProperty("toInstaMember")) : null;
+    }
+
+}
+

--- a/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
+++ b/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
@@ -1,0 +1,16 @@
+package com.ll.gramgram.base.appConfig;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+    @Getter
+    private static long likeablePersonFromMax;
+
+    @Value("${custom.likeablePerson.from.max}")
+    public void setLikeablePersonFromMax(long likeablePersonFromMax){
+        AppConfig.likeablePersonFromMax=likeablePersonFromMax;
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/baseEntity/BaseEntity.java
+++ b/src/main/java/com/ll/gramgram/base/baseEntity/BaseEntity.java
@@ -1,0 +1,34 @@
+package com.ll.gramgram.base.baseEntity;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@MappedSuperclass
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@ToString
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy=IDENTITY)
+    private Long id;
+    @CreatedDate
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/ll/gramgram/base/baseEntity/BaseEntity.java
+++ b/src/main/java/com/ll/gramgram/base/baseEntity/BaseEntity.java
@@ -1,6 +1,5 @@
 package com.ll.gramgram.base.baseEntity;
 
-
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -25,7 +24,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @ToString
 public class BaseEntity {
     @Id
-    @GeneratedValue(strategy=IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
     @CreatedDate
     private LocalDateTime createDate;

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -24,15 +24,26 @@ public class NotProd {
             Member memberUser2 = memberService.join("user2", "1234").getData();
             Member memberUser3 = memberService.join("user3", "1234").getData();
             Member memberUser4 = memberService.join("user4", "1234").getData();
-
+            Member memberUser5 = memberService.join("user5","1234").getData();
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733191015").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");
             instaMemberService.connect(memberUser4, "insta_user4", "M");
+            instaMemberService.connect(memberUser4, "insta_user5", "W");
 
             likeablePersonService.like(memberUser3, "insta_user4", 1);
             likeablePersonService.like(memberUser3, "insta_user100", 2);
-        };
+            likeablePersonService.like(memberUser5, "insta_user101", 2);
+            likeablePersonService.like(memberUser5, "insta_user102", 2);
+            likeablePersonService.like(memberUser5, "insta_user103", 2);
+            likeablePersonService.like(memberUser5, "insta_user104", 2);
+            likeablePersonService.like(memberUser5, "insta_user105", 2);
+            likeablePersonService.like(memberUser5, "insta_user106", 2);
+            likeablePersonService.like(memberUser5, "insta_user107", 2);
+            likeablePersonService.like(memberUser5, "insta_user108", 2);
+            likeablePersonService.like(memberUser5, "insta_user109", 2);
+            likeablePersonService.like(memberUser5, "insta_user110", 2);
+             };
     }
 }

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -25,7 +25,9 @@ public class NotProd {
             Member memberUser3 = memberService.join("user3", "1234").getData();
             Member memberUser4 = memberService.join("user4", "1234").getData();
             Member memberUser5 = memberService.join("user5","1234").getData();
-            Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733191015").getData();
+            Member memberUser6ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733191015").getData();
+            Member memberUser7ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__4eTJY8rdhl1uv-gv5PP8YgNQ3UcoCRWFa5_zdJOAvbU").getData();
+            Member memberUser8ByGOOGLE = memberService.whenSocialLogin("GOOGLE", "GOOGLE__115052980621736075605").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.ll.gramgram.base.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
@@ -30,17 +30,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        String oauthId = oAuth2User.getName();
-
-
         String providerTypeCode = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
 
 
-       if(providerTypeCode.equals("NAVER")){ //naver일 경우 id 추출하기
-           int start= oauthId.indexOf("id=");
-           int end=oauthId.indexOf(",");
-           oauthId=oauthId.substring(start+3,end);
-        }
+        String oauthId = switch (providerTypeCode) {
+            case "NAVER" -> ((Map<String, String>) oAuth2User.getAttributes().get("response")).get("id");
+            default -> oAuth2User.getName();
+        };
 
         String username = providerTypeCode + "__%s".formatted(oauthId);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -54,4 +54,12 @@ public class InstaMember {
     public void addToLikeablePerson(LikeablePerson likeablePerson) {
         toLikeablePeople.add(0, likeablePerson);
     }
+
+    public void removeFromLikeablePerson(LikeablePerson likeablePerson){
+        fromLikeablePeople.removeIf(e-> e.equals(likeablePerson));
+    }
+
+    public void removeToLikeablePerson(LikeablePerson likeablePerson){
+        toLikeablePeople.removeIf(e->e.equals(likeablePerson));
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,35 +1,24 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.base.baseEntity.BaseEntity;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-@ToString
+
+
 @Entity
 @Getter
-public class InstaMember {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class InstaMember extends BaseEntity {
     @Column(unique = true)
     private String username;
     @Setter

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -43,6 +43,10 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()") //로그인 여부 확인
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
+        RsData canLikeRsData=likeablePersonService.canLike(rq.getMember(),addForm.getUsername(),addForm.getAttractiveTypeCode());
+
+        if(canLikeRsData.isFail()) return rq.historyBack(canLikeRsData);
+
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (createRsData.isFail()) {
@@ -70,10 +74,9 @@ public class LikeablePersonController {
     @DeleteMapping("/{id}")
     public String delete(@PathVariable Long id){
 
-
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
+        RsData canActorDeleteRsData = likeablePersonService.canDelete(rq.getMember(), likeablePerson);
 
         if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -47,13 +47,18 @@ public class LikeablePersonController {
 
         if(canLikeRsData.isFail()) return rq.historyBack(canLikeRsData);
 
-        RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
+        RsData rsData;
 
-        if (createRsData.isFail()) {
-            return rq.historyBack(createRsData);
+        if(canLikeRsData.getResultCode().equals("S-2")){
+            rsData=likeablePersonService.modifyAttractive(rq.getMember(),addForm.getUsername(), addForm.getAttractiveTypeCode());
+        }else{
+            rsData=likeablePersonService.like(rq.getMember(),addForm.getUsername(), addForm.getAttractiveTypeCode());
         }
 
-        return rq.redirectWithMsg("/likeablePerson/list", createRsData);
+        if(rsData.isFail()){
+            return rq.historyBack(rsData);
+        }
+        return rq.redirectWithMsg("/likeablePerson/list", rsData);
     }
 
     @PreAuthorize("isAuthenticated()") //로그인 여부 확인

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -43,18 +43,8 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()") //로그인 여부 확인
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
-        RsData canLikeRsData=likeablePersonService.canLike(rq.getMember(),addForm.getUsername(),addForm.getAttractiveTypeCode());
-
-        if(canLikeRsData.isFail()) return rq.historyBack(canLikeRsData);
-
-        RsData rsData;
-
-        if(canLikeRsData.getResultCode().equals("S-2")){
-            rsData=likeablePersonService.modifyAttractive(rq.getMember(),addForm.getUsername(), addForm.getAttractiveTypeCode());
-        }else{
-            rsData=likeablePersonService.like(rq.getMember(),addForm.getUsername(), addForm.getAttractiveTypeCode());
-        }
-
+        RsData<LikeablePerson> rsData=likeablePersonService.like(rq.getMember(),
+                addForm.getUsername(),addForm.getAttractiveTypeCode());
         if(rsData.isFail()){
             return rq.historyBack(rsData);
         }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -21,6 +21,7 @@ public class LikeablePerson extends BaseEntity {
     @ToString.Exclude
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
+    @Setter
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)
 
     public String getAttractiveTypeDisplayName() {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -1,34 +1,18 @@
 package com.ll.gramgram.boundedContext.likeablePerson.entity;
 
+import com.ll.gramgram.base.baseEntity.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
-import java.util.List;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
-
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-@ToString
-@Entity
 @Getter
 @Setter
-public class LikeablePerson {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
-
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class LikeablePerson extends BaseEntity {
     @ManyToOne
     @ToString.Exclude
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -19,6 +19,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @ToString
 @Entity
 @Getter
+@Setter
 public class LikeablePerson {
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-
+@Entity
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
     List<LikeablePerson> findByFromInstaMemberIdAndToInstaMemberId(Long fromInstaMemberId, Long toInstaMemberId);
+    List<LikeablePerson>findByToInstaMemberIdAndAttractiveTypeCode(Long toInstaMemberId,int attractiveTypeCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
+    List<LikeablePerson> findByFromInstaMemberIdAndToInstaMemberId(Long fromInstaMemberId, Long toInstaMemberId);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -4,9 +4,14 @@ import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
-    List<LikeablePerson> findByFromInstaMemberIdAndToInstaMemberId(Long fromInstaMemberId, Long toInstaMemberId);
-    List<LikeablePerson>findByToInstaMemberIdAndAttractiveTypeCode(Long toInstaMemberId,int attractiveTypeCode);
+    List<LikeablePerson> findByToInstaMember_username(String username);
+
+    LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String username);
+
+    Optional<LikeablePerson> findByFromInstaMember_usernameAndToInstaMember_username(String fromInstaMemberUsername, String toInstaMemberUsername);
+
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -6,12 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long>, LikeablePersonRepositoryCustom {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
+
     List<LikeablePerson> findByToInstaMember_username(String username);
 
     LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String username);
 
     Optional<LikeablePerson> findByFromInstaMember_usernameAndToInstaMember_username(String fromInstaMemberUsername, String toInstaMemberUsername);
-
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+
+import java.util.Optional;
+
+public interface LikeablePersonRepositoryCustom {
+    Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
+
+@RequiredArgsConstructor
+public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(likeablePerson)
+                        .where(
+                                likeablePerson.fromInstaMember.id.eq(fromInstaMemberId)
+                                        .and(
+                                                likeablePerson.toInstaMember.username.eq(toInstaMemberUsername)
+                                        )
+                        )
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -43,10 +43,12 @@ public class LikeablePersonService {
             return RsData.of("F-3", "이미 호감을 등록한 상대입니다.");
         }
 
-        // 등록한 호감상대의 사유가 변경 되었다면, likeable db에서 기존에 추가 되었던 것을 삭제
+        // 이미 등록한 호감 상대의 호감 사유가 다르다면 수정
         else if(!toLikeableList.isEmpty()&&toLikeableAttractiveTypeCode.isEmpty()){
-            update=true;
-            likeablePersonRepository.delete(toLikeableList.get(0));
+            LikeablePerson attractiveTypeCodeModify=toLikeableList.get(0);
+            attractiveTypeCodeModify.setAttractiveTypeCode(attractiveTypeCode);
+            likeablePersonRepository.save(attractiveTypeCodeModify);
+            return RsData.of("S-1","호감상대 %s유저 사유 변경".formatted(toInstaMember.getUsername()),attractiveTypeCodeModify);
         }
 
         // 최대 10명까지 등록가능
@@ -63,14 +65,6 @@ public class LikeablePersonService {
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
                 .attractiveTypeCode(attractiveTypeCode) // 1=외모, 2=능력, 3=성격
                 .build();
-
-        // 사유가 변경 되었다면, 사유 변경하여 다시 save
-        if (update==true){
-            LikeablePerson modifyAttraciveTypeCode=likeablePerson;
-            modifyAttraciveTypeCode.setAttractiveTypeCode(attractiveTypeCode);
-            likeablePersonRepository.save(modifyAttraciveTypeCode);
-            return RsData.of("S-1","호감상대 %s유저 사유 변경".formatted(toInstaMember.getUsername()),modifyAttraciveTypeCode);
-        }
 
         likeablePersonRepository.save(likeablePerson); // 저장
         // 너가 좋아하는 호감표시

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+
+import com.ll.gramgram.base.appConfig.AppConfig;
 import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
@@ -14,13 +16,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LikeablePersonService {
     private final LikeablePersonRepository likeablePersonRepository;
     private final InstaMemberService instaMemberService;
-    private boolean update;
     @Transactional
     public RsData<LikeablePerson> like(Member member, String username, int attractiveTypeCode) {
 
@@ -34,28 +36,6 @@ public class LikeablePersonService {
 
         InstaMember fromInstaMember = member.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
-
-        List<LikeablePerson> toLikeableAttractiveTypeCode=likeablePersonRepository.findByToInstaMemberIdAndAttractiveTypeCode(toInstaMember.getId(),attractiveTypeCode);
-
-        //이미 등록한 호감 상대는 등록할 수 x
-        List<LikeablePerson> toLikeableList = likeablePersonRepository.findByFromInstaMemberIdAndToInstaMemberId(fromInstaMember.getId(), toInstaMember.getId());
-        if (!toLikeableList.isEmpty()&&!toLikeableAttractiveTypeCode.isEmpty()) {
-            return RsData.of("F-3", "이미 호감을 등록한 상대입니다.");
-        }
-
-        // 이미 등록한 호감 상대의 호감 사유가 다르다면 수정
-        else if(!toLikeableList.isEmpty()&&toLikeableAttractiveTypeCode.isEmpty()){
-            LikeablePerson attractiveTypeCodeModify=toLikeableList.get(0);
-            attractiveTypeCodeModify.setAttractiveTypeCode(attractiveTypeCode);
-            likeablePersonRepository.save(attractiveTypeCodeModify);
-            return RsData.of("S-1","호감상대 %s유저 사유 변경".formatted(toInstaMember.getUsername()),attractiveTypeCodeModify);
-        }
-
-        // 최대 10명까지 등록가능
-       List<LikeablePerson> fromlikeablePersonList=likeablePersonRepository.findByFromInstaMemberId(fromInstaMember.getId());
-        if(fromlikeablePersonList.size()>9){
-           return RsData.of("F-4","최대 10명까지 등록할 수 있습니다.");
-        }
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
@@ -98,7 +78,7 @@ public class LikeablePersonService {
     return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(likeCanceledUsername));
     }
 
-    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson){
+    public RsData canDelete(Member actor, LikeablePerson likeablePerson){
         if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
 
         // 수행자의 인스타계정 번호
@@ -110,5 +90,40 @@ public class LikeablePersonService {
             return RsData.of("F-2", "권한이 없습니다.");
 
         return RsData.of("S-1", "삭제가능합니다.");
+    }
+
+    public RsData canLike(Member actor, String username, int attractiveTypeCode){
+        if(!actor.hasConnectedInstaMember()){
+            return RsData.of("F-1","먼저 본인의 인스타그램 아이디를 입력해주세요.");
+        }
+        InstaMember fromInstaMember=actor.getInstaMember();
+
+        if(fromInstaMember.getUsername().equals(username)){
+            return RsData.of("F-2","본인을 호감상대로 등록할 수 없습니다.");
+        }
+        //액터기 생성한 좋아요 가져오기
+        List<LikeablePerson> fromLikeablePeople=fromInstaMember.getFromLikeablePeople();
+
+        LikeablePerson fromLikeablePerson=fromLikeablePeople
+                .stream()
+                .filter(e->e.getToInstaMember().getUsername().equals(username))
+                .findFirst()
+                .orElse(null);
+
+        long likeablePersonFromMax = AppConfig.getLikeablePersonFromMax();
+
+        if(fromLikeablePerson!=null && fromLikeablePerson.getAttractiveTypeCode()==attractiveTypeCode){
+            return RsData.of("F-3","이미 %s님에 대해서 호감표시를 했습니다.".formatted(username));
+        }
+
+        if(fromLikeablePeople.size()>=likeablePersonFromMax){
+            return RsData.of("F-4","최대 %d명에 대해서만 호감 표시가 가능합니다.".formatted(likeablePersonFromMax));
+        }
+
+        if(fromLikeablePerson!=null){
+            return RsData.of("S-2","%s님에 대해서 호감표시가 가능합니다.".formatted(username));
+        }
+
+        return RsData.of("S-1","%s님에 대해서 호감표시가 가능합니다.".formatted(username));
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -66,10 +66,10 @@ public class LikeablePersonService {
 
         // 사유가 변경 되었다면, 사유 변경하여 다시 save
         if (update==true){
-            LikeablePerson duplicateAttractive=likeablePerson;
-            duplicateAttractive.setAttractiveTypeCode(attractiveTypeCode);
-            likeablePersonRepository.save(duplicateAttractive);
-            return RsData.of("S-1","호감상대 %s유저 사유 변경".formatted(toInstaMember.getUsername()),duplicateAttractive);
+            LikeablePerson modifyAttraciveTypeCode=likeablePerson;
+            modifyAttraciveTypeCode.setAttractiveTypeCode(attractiveTypeCode);
+            likeablePersonRepository.save(modifyAttraciveTypeCode);
+            return RsData.of("S-1","호감상대 %s유저 사유 변경".formatted(toInstaMember.getUsername()),modifyAttraciveTypeCode);
         }
 
         likeablePersonRepository.save(likeablePerson); // 저장

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -115,12 +115,12 @@ public class LikeablePersonService {
             return RsData.of("F-3", "이미 %s님에 대해서 호감표시를 했습니다.".formatted(username));
         }
 
-        if (fromLikeablePeople.size() >= likeablePersonFromMax) {
-            return RsData.of("F-4", "최대 %d명에 대해서만 호감 표시가 가능합니다.".formatted(likeablePersonFromMax));
-        }
-
         if (fromLikeablePerson != null) {
             return RsData.of("S-2", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));
+        }
+
+        if(fromLikeablePeople.size()>=likeablePersonFromMax){
+            return RsData.of("F-4","최대 %d명에 대해서만 호감표시가 가능합니다.".formatted(likeablePersonFromMax));
         }
 
         return RsData.of("S-1", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -38,14 +38,14 @@ public class LikeablePersonService {
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         //이미 등록한 호감 상대는 등록할 수 x
-        List<LikeablePerson> Likeables = likeablePersonRepository.findByFromInstaMemberIdAndToInstaMemberId(fromInstaMember.getId(), toInstaMember.getId());
-        if (!Likeables.isEmpty()) {
+        List<LikeablePerson> toLikeableList = likeablePersonRepository.findByFromInstaMemberIdAndToInstaMemberId(fromInstaMember.getId(), toInstaMember.getId());
+        if (!toLikeableList.isEmpty()) {
             return RsData.of("F-3", "이미 호감을 등록한 상대입니다.");
         }
 
         // 최대 10명까지 등록가능
-       List<LikeablePerson> likeablePersonList=likeablePersonRepository.findByFromInstaMemberId(fromInstaMember.getId());
-        if(likeablePersonList.size()>9){
+       List<LikeablePerson> fromlikeablePersonList=likeablePersonRepository.findByFromInstaMemberId(fromInstaMember.getId());
+        if(fromlikeablePersonList.size()>9){
             return RsData.of("F-4","최대 10명까지 등록할 수 있습니다.");
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -25,23 +25,20 @@ public class LikeablePersonService {
     private final InstaMemberService instaMemberService;
 
     @Transactional
-    public RsData<LikeablePerson> like(Member member, String username, int attractiveTypeCode) {
+    public RsData<LikeablePerson> like(Member actor, String username, int attractiveTypeCode) {
+        RsData canLikeRsData=canLike(actor,username,attractiveTypeCode);
 
-        if (member.hasConnectedInstaMember() == false) {
-            return RsData.of("F-2", "먼저 본인의 인스타그램 아이디를 입력해야 합니다.");
-        }
+        if(canLikeRsData.isFail()) return canLikeRsData;
+        if(canLikeRsData.getResultCode().equals("S-2")) return modifyAttractive(actor,username,attractiveTypeCode);
 
-        if (member.getInstaMember().getUsername().equals(username)) {
-            return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");
-        }
 
-        InstaMember fromInstaMember = member.getInstaMember();
+        InstaMember fromInstaMember = actor.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
                 .fromInstaMember(fromInstaMember) // 호감을 표시하는 사람의 인스타 멤버
-                .fromInstaMemberUsername(member.getInstaMember().getUsername()) // 중요하지 않음
+                .fromInstaMemberUsername(actor.getInstaMember().getUsername()) // 중요하지 않음
                 .toInstaMember(toInstaMember) // 호감을 받는 사람의 인스타 멤버
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
                 .attractiveTypeCode(attractiveTypeCode) // 1=외모, 2=능력, 3=성격
@@ -93,7 +90,7 @@ public class LikeablePersonService {
         return RsData.of("S-1", "삭제가능합니다.");
     }
 
-    public RsData canLike(Member actor, String username, int attractiveTypeCode) {
+    private RsData canLike(Member actor, String username, int attractiveTypeCode) {
         if (!actor.hasConnectedInstaMember()) {
             return RsData.of("F-1", "먼저 본인의 인스타그램 아이디를 입력해주세요.");
         }
@@ -105,6 +102,7 @@ public class LikeablePersonService {
         //액터기 생성한 좋아요 가져오기
         List<LikeablePerson> fromLikeablePeople = fromInstaMember.getFromLikeablePeople();
 
+        // 그 중에서 좋아하는 상대가 username인 녀석이 혹시 있는지 체크
         LikeablePerson fromLikeablePerson = fromLikeablePeople
                 .stream()
                 .filter(e -> e.getToInstaMember().getUsername().equals(username))
@@ -128,10 +126,10 @@ public class LikeablePersonService {
         return RsData.of("S-1", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));
     }
 
-    @Transactional
-    public RsData modifyAttractive(Member member, String username, int attractiveTypeCode) {
+    private RsData<LikeablePerson> modifyAttractive(Member member, String username, int attractiveTypeCode){
         List<LikeablePerson> fromLikeablePeople = member.getInstaMember().getFromLikeablePeople();
 
+        //액터가 생성한 좋아요들 가져오기
         LikeablePerson fromLikeablePerson = fromLikeablePeople
                 .stream()
                 .filter(e ->
@@ -149,7 +147,7 @@ public class LikeablePersonService {
         likeablePersonRepository.save(fromLikeablePerson);
         String newAttractiveTypeDisplayName = fromLikeablePerson.getAttractiveTypeDisplayName();
 
-        return RsData.of("S-3", "%s님에 대한 호감사유를 %s에서 %s으로 변경합니다.".formatted(username, oldAttractiveTypeDisplayName, newAttractiveTypeDisplayName));
+        return RsData.of("S-3", "%s님에 대한 호감사유를 %s에서 %s으로 변경합니다.".formatted(username, oldAttractiveTypeDisplayName, newAttractiveTypeDisplayName),fromLikeablePerson);
     }
 
     public Optional<LikeablePerson> findByFromInstaMember_usernameAndToInstaMember_username(String fromInstaMemberUsername, String toInstaMemberUsername) {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -86,8 +86,15 @@ public class LikeablePersonService {
 
     @Transactional //트랜잭션은 private로 전파되지 않는다. 실제 구현체에서 제공하는 sava,delete가 아니라면 트랜잭션 붙이기
     public RsData delete(LikeablePerson likeablePerson){
+
+        //너가 생성한 좋아요가 사라졌어.
+        likeablePerson.getFromInstaMember().removeToLikeablePerson(likeablePerson);
+
+        //너가 받은 좋아요가 사라졌어.
+        likeablePerson.getToInstaMember().removeToLikeablePerson(likeablePerson);
+
         likeablePersonRepository.delete(likeablePerson);
-    String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();
+        String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();
     return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(likeCanceledUsername));
     }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -5,17 +5,11 @@ import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.member.entity;
 
+import com.ll.gramgram.base.baseEntity.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,21 +17,12 @@ import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder // Member.builder().providerTypeCode(providerTypeCode) .. 이런식으로 쓸 수 있게 해주는
-@NoArgsConstructor // @Builder 붙이면 이거 필수
-@AllArgsConstructor // @Builder 붙이면 이거 필수
-@EntityListeners(AuditingEntityListener.class) // @CreatedDate, @LastModifiedDate 작동하게 허용
-@ToString // 디버그를 위한
-@Entity // 아래 클래스는 member 테이블과 대응되고, 아래 클래스의 객체는 테이블의 row와 대응된다.
-@Getter // 아래 필드에 대해서 전부다 게터를 만든다. private Long id; => public Long getId() { ... }
-public class Member {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate // 아래 칼럼에는 값이 자동으로 들어간다.(INSERT 할 때)
-    private LocalDateTime createDate;
-    @LastModifiedDate // 아래 칼럼에는 값이 자동으로 들어간다.(UPDATE 할 때 마다)
-    private LocalDateTime modifyDate;
+@Entity
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class Member extends BaseEntity {
     private String providerTypeCode; // 일반회원인지, 카카오로 가입한 회원인지, 구글로 가입한 회원인지
     @Column(unique = true)
     private String username;

--- a/src/main/resources/templates/usr/instaMember/connect.html
+++ b/src/main/resources/templates/usr/instaMember/connect.html
@@ -40,7 +40,7 @@
     <form th:action method="POST" class="p-10 max-w-sm flex flex-col gap-4"
           onsubmit="ConnectForm__submit(this); return false;">
         <div>
-            <input type="text" name="username" autocomplete="off" maxlength="30" placeholder="인스타그램 아이디"
+            <input type="text" name="username" maxlength="30" placeholder="인스타그램 아이디"
                    class="input input-bordered">
         </div>
         <div>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -42,7 +42,8 @@
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
     <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
-    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}" th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}"
+          th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/likeablePerson/add.html
+++ b/src/main/resources/templates/usr/likeablePerson/add.html
@@ -60,7 +60,7 @@
                 당신의 인스타ID : <span class="badge" th:text="${@rq.member.instaMember.username}"></span>
             </div>
             <div>
-                <input type="text" name="username" autocomplete="off" maxlength="30" placeholder="상대방의 인스타그램 아이디"
+                <input type="text" name="username" maxlength="30" placeholder="상대방의 인스타그램 아이디"
                        class="input input-bordered">
             </div>
             <div>

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -2,6 +2,7 @@ package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
 import com.ll.gramgram.base.appConfig.AppConfig;
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -297,5 +300,33 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().methodName("add"))
                 .andExpect(status().is4xxClientError());
         ;
+    }
+    @Test
+    @DisplayName("기존에 호감을 표시한 유저에게 새로운 사유로 호감을 표시하면 추가가 아니라 수정이 된다.")
+    @WithUserDetails("user3")
+    void t013() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "2")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is3xxRedirection());
+        ;
+
+        Optional<LikeablePerson> opLikeablePerson = likeablePersonService.findByFromInstaMember_usernameAndToInstaMember_username("insta_user3", "insta_user4");
+
+        int newAttractiveTypeCode = opLikeablePerson
+                .map(LikeablePerson::getAttractiveTypeCode)
+                .orElse(-1);
+
+        assertThat(newAttractiveTypeCode).isEqualTo(2);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,6 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
+import com.ll.gramgram.base.appConfig.AppConfig;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -213,5 +214,13 @@ public class LikeablePersonControllerTests {
         ;
 
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("설정파일에 있는 최대가능호감표시 수 가져오기")
+    void t009() throws  Exception{
+        long likeablePersonFromMax= AppConfig.getLikeablePersonFromMax();
+
+        assertThat(likeablePersonFromMax).isEqualTo(10);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -217,10 +217,85 @@ public class LikeablePersonControllerTests {
     }
 
     @Test
-    @DisplayName("설정파일에 있는 최대가능호감표시 수 가져오기")
-    void t009() throws  Exception{
-        long likeablePersonFromMax= AppConfig.getLikeablePersonFromMax();
+    @DisplayName("인스타아이디가 없는 회원에 대해서 호감표시를 할 수 없다.")
+    @WithUserDetails("user1")
+    void t009() throws Exception{
+        //WHEN
+       ResultActions resultActions=mvc
+               .perform(post("/likeablePerson/add")
+               .with(csrf()) //CSRF 생성
+               .param("username","insta_user4")
+               .param("attractiveTypeCode","1")
+               )
+        .andDo(print());
 
-        assertThat(likeablePersonFromMax).isEqualTo(10);
+        //THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
+   }
+
+   @Test
+   @DisplayName("본인이 본인에게 호감 표시하면 안된다.")
+   @WithUserDetails("user3")
+   void t010()throws Exception{
+       // WHEN
+       ResultActions resultActions = mvc
+               .perform(post("/likeablePerson/add")
+                       .with(csrf()) // CSRF 키 생성
+                       .param("username", "insta_user3")
+                       .param("attractiveTypeCode", "1")
+               )
+               .andDo(print());
+       //THEN
+       resultActions
+
+               .andExpect(handler().handlerType(LikeablePersonController.class))
+               .andExpect(handler().methodName("add"))
+               .andExpect(status().is4xxClientError());
+       ;
+   }
+    @Test
+    @DisplayName("특정인에 대해서 호감표시를 중복으로 시도하면 안된다.")
+    @WithUserDetails("user3")
+    void t011() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
+    }
+
+    @Test
+    @DisplayName("한 회원은 호감표시를 할 수 있는 최대 인원이 정해져 있다.")
+    @WithUserDetails("user5")
+    void t012() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user111")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
     }
 }


### PR DESCRIPTION
# 2Week_제문경.md

## Title: [2Week] 제문경

### 미션 요구사항 분석 & 체크리스트 🔍

---
- [x]  이미 등록된 호감 상대의  호감 사유가 이전과 같다면 `insert`하지 못함
- [x]  이미 등록된 호감 상대의  호감 사유가 이전과 다르다면 `update` 수행
- [x]  호감 상대추가는 10명까지 가능
- [x]  호감 상대가 10명 이상이라면 경고창과 함께 추가 안 되도록 구현
- [ ]  각 기능에 대한 테스트 코드
- [x]  네이버 로그인

<br>

### N주차 미션 요약 📋

---

**[접근 방법]**

1. **목표**
- 이미 호감을 표시한 상대가 같은 사유로 호감표시를 했다면, 경고창과 함께 추가 안되도록 구현
    - likeable_person 테이블에서 insert가 되면 안됨
    - 구현 방법: from과 to InstamemberId를 repository에 추가, toInstaMemberId와 attractiveTypeCode를 repository에 추가하여 List로 받아와서 이미 존재하는 from, to id이고 attrativeTypeCode도 같다면 추가되지 않도록 구현
    - from,to InstaMemberId는 같지만 attractiveTypeCode가 다르다면 변경한 호감 사유로 set하고 save하여 저장 

- 호감 상대는 최대 10명까지 등록가능
    - fromInstaMemberId를 List로 받아와 10명이상일 경우 경고창과 함께 추가 안되도록 구현

- 네이버 로그인
    - 1Week 미션 수행 당시 구현, 네이버는 다른 정보들이 같이 나오기 때문에 id=이후로 ,가 오기 전까지 잘라서 저장하여 id만 저장될 수 있도록 구현

---
<br>

**[특이사항]**

1. 궁금했던 점

   이미 호감을 표시한 상대의 attractiveTypeCode가 변경 되었다면 다시 set하고 저장하였는데, 처음에 DB에 반영되지 않았고 그 이유에 대해 궁금하였는데 attractiveTypeCode로만 Set하여 안 되었던 부분 같았습니다. to,from InstaMemberId로 get하여 가져온 list에 해당하는 attractiveTypeCode를 변경하니 잘 수행되었습니다.


2. 아쉬웠던 점

  각 기능에 대한 테스팅 코드를 작성하지 못한 부분이 가장 아쉬웠던 것 같습니다. 

<br>

[Refactoring]

- 호감상대 10이상일 경우 test 코드
- 이미 추가한 호감상대의 사유가 같다면 추가 안 되도록 test 코드 구현
- 사유가 같지 않다면 update 되도록 test 코드 구현
- 사유가 같지 않을 때 update가 실행될 수 있는 코드 리팩토링

<br>

[1️⃣Week Refactoring ]

- [x]  호감 목록 중 선택 상대 삭제 메소드 코드 리팩토링
- [x]  호감 목록 삭제 테스트 코드 추가
- [x]  yml ouath파일로 나누어 보이지 않도록
- [x]  로그인 UI 변경